### PR TITLE
各評価項目の型とデフォルト値を修正しました。

### DIFF
--- a/src/database/migrations/2020_04_04_155208_add_column_to_cafes_table.php
+++ b/src/database/migrations/2020_04_04_155208_add_column_to_cafes_table.php
@@ -15,9 +15,9 @@ class AddColumnToCafesTable extends Migration
     {
         Schema::table('cafes', function (Blueprint $table) {
             $table->string('place', 256)->after('name');
-            $table->string('food_evaluation', 256)->after('place');
-            $table->string('access_evaluation', 256)->after('food_evaluation');
-            $table->string('feeling_evaluation', 256)->after('access_evaluation');
+            $table->integer('food_evaluation')->default(0)->after('place');
+            $table->integer('access_evaluation')->default(0)->after('food_evaluation');
+            $table->integer('feeling_evaluation')->default(0)->after('access_evaluation');
         });
     }
 


### PR DESCRIPTION
## 概要
* 評価項目を保存するテーブルの型が文字列になっていたので修正しました。
* 評価項目のデフォルト値を`0`（評価不能）としました。

## migrateを実行してください。
```bash
# ↓これを先に実行
docker-compose exec php php artisan migrate:rollback

# ↓次にこれを実行
docker-compose exec php php artisan migrate
```
